### PR TITLE
Fix "Device information ... not found" errors with modern libwacom versions

### DIFF
--- a/wacom-gui/wacom_data.py
+++ b/wacom-gui/wacom_data.py
@@ -122,7 +122,7 @@ class Tablets:
 
 
     def __get_libwacom_data(self):
-        p = subprocess.Popen("libwacom-list-local-devices --database %s" % self.db_path, shell=True,
+        p = subprocess.Popen("libwacom-list-local-devices --database '%s' --format=datafile" % self.db_path, shell=True,
                              stdout=subprocess.PIPE)
         output = p.communicate()[0].decode('utf-8').split('\n')
         cur_device = None


### PR DESCRIPTION
This PR fixes #68, by adding compatibility with libwacom >= 1.10, while maintaining compatibility with older versions.

This fixes wacom-gui compatibility with:
* Ubuntu: >= 22.04 LTS
* Debian: >= 12 (bookworm) (i.e. the current version)
* Fedora >= 36
* CentOS >= 9
* Arch
* Gentoo

In particular, I've tested this on Ubuntu 22.04 LTS. By the way, the necessary dependencies for Ubuntu are: libwacom-bin, xserver-xorg-input-wacom, python3-pyqt5, python3-pyqt5.qtsvg in case you want to add them to the README. libwacom-bin is the Ubuntu and Debian equivalent to libwacom in RPM systems, e.g. libwacom-2.7.0-1.fc38.x86_64.rpm for Fedora 38.