### PR TITLE
Fix #70 gestures always loading as disabled

### DIFF
--- a/wacom-gui/pad.py
+++ b/wacom-gui/pad.py
@@ -301,7 +301,7 @@ class Touch(QWidget):
             self.gesture.setEnabled(True)
         self.gesture.setChecked(False)
         if 'gesture' in settings.keys() and settings['gesture'] == 'on' and self.gesture.isEnabled():
-            self.touch.setChecked(True)
+            self.gesture.setChecked(True)
         if 'taptime' in settings.keys():
             self.taptime = WacomAttribSlider(self.dev_id, 'taptime', 250, "Double Tap Time (ms)", 0, 500, 25,
                                                 int(settings['taptime']))


### PR DESCRIPTION
This PR closes #70, whereby the gestures checkbox doesn't initialise correctly from the config file. It always loads as off, regardless of the saved config. That means the gestures functionality will be disabled in the tablet.

The fix is actually just correcting a simple typo.